### PR TITLE
Fix day counter not incrementing, add support for `PLAYER_SLEEP_PERCENTAGE` gamerule, add raid timer speedup, bump version number to 1.6.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.19
 yarn_mappings=1.19+build.4
 loader_version=0.14.8
 # Mod Properties
-mod_version=1.5.3
+mod_version=1.6.0
 maven_group=com.github.steveplays28
 archives_base_name=realisticsleep
 # Dependencies

--- a/src/main/java/com/github/steveplays28/realisticsleep/SleepMath.java
+++ b/src/main/java/com/github/steveplays28/realisticsleep/SleepMath.java
@@ -2,28 +2,25 @@ package com.github.steveplays28.realisticsleep;
 
 public class SleepMath {
 	public static final int DAY_LENGTH = 24000;
-	public static final int AWAKE_TIME = 23460;
+	public static final int AWAKE_TIME = 24000;
 
 	public static int calculateNightTimeStepPerTick(double sleepingRatio, double multiplier) {
 		return (int) Math.round(sleepingRatio * multiplier);
 	}
 
-	public static int calculateTicksTo(int timeOfDay, int targetTimeOfDay) {
-		if (timeOfDay > targetTimeOfDay)
-			return targetTimeOfDay + DAY_LENGTH - timeOfDay;
-
+	public static int calculateTicksToTimeOfDay(int timeOfDay, int targetTimeOfDay) {
 		return targetTimeOfDay - timeOfDay;
 	}
 
 	public static int calculateTicksUntilAwake(int currentTimeOfDay) {
-		return calculateTicksTo(currentTimeOfDay, AWAKE_TIME);
+		return calculateTicksToTimeOfDay(currentTimeOfDay, AWAKE_TIME);
 	}
 
 	public static int calculateSecondsUntilAwake(int currentTimeOfDay, double timeStepPerTick, double tps) {
 		return (int) Math.round(calculateTicksUntilAwake(currentTimeOfDay) / timeStepPerTick / tps);
 	}
 
-	public static double getRandomNumber(double min, double max) {
+	public static double getRandomNumberInRange(double min, double max) {
 		return (Math.random() * (max - min)) + min;
 	}
 }

--- a/src/main/java/com/github/steveplays28/realisticsleep/config/RealisticSleepConfig.java
+++ b/src/main/java/com/github/steveplays28/realisticsleep/config/RealisticSleepConfig.java
@@ -8,7 +8,6 @@ import me.shedaniel.autoconfig.annotation.ConfigEntry;
 public class RealisticSleepConfig implements ConfigData {
 	@ConfigEntry.Gui.Tooltip
 	public String dawnMessage = "The sun rises.";
-	@ConfigEntry.BoundedDiscrete(min = 1, max = 200)
 	@ConfigEntry.Gui.Tooltip
 	public int sleepSpeedMultiplier = 25;
 	@ConfigEntry.BoundedDiscrete(min = 1, max = 200)
@@ -17,4 +16,7 @@ public class RealisticSleepConfig implements ConfigData {
 	@ConfigEntry.BoundedDiscrete(min = 1, max = 200)
 	@ConfigEntry.Gui.Tooltip
 	public int chunkTickSpeedMultiplier = 25;
+	@ConfigEntry.BoundedDiscrete(min = 1, max = 200)
+	@ConfigEntry.Gui.Tooltip
+	public int raidTickSpeedMultiplier = 25;
 }

--- a/src/main/java/com/github/steveplays28/realisticsleep/mixin/ServerWorldMixin.java
+++ b/src/main/java/com/github/steveplays28/realisticsleep/mixin/ServerWorldMixin.java
@@ -62,10 +62,23 @@ public abstract class ServerWorldMixin extends World {
 		// Fetch values and do calculations
 		int playerCount = server.getCurrentPlayerCount();
 		double sleepingRatio = (double) sleepingPlayerCount / playerCount;
+		double sleepingPercentage = sleepingRatio * 100;
 		int nightTimeStepPerTick = SleepMath.calculateNightTimeStepPerTick(sleepingRatio, config.sleepSpeedMultiplier);
 		int blockEntityTickSpeedMultiplier = (int) Math.round((double) config.blockEntityTickSpeedMultiplier);
 		int chunkTickSpeedMultiplier = (int) Math.round((double) config.chunkTickSpeedMultiplier);
 		boolean dayLightCycle = server.getGameRules().getBoolean(GameRules.DO_DAYLIGHT_CYCLE);
+		int playersRequiredToSleepPercentage = server.getGameRules().getInt(GameRules.PLAYERS_SLEEPING_PERCENTAGE);
+		double playersRequiredToSleepRatio = server.getGameRules().getInt(GameRules.PLAYERS_SLEEPING_PERCENTAGE) / 100;
+		int playersRequiredToSleep = (int) Math.ceil(playersRequiredToSleepRatio * playerCount);
+
+		// Check if the required percentage of players are sleeping
+		if (sleepingPercentage < playersRequiredToSleepPercentage) {
+			for (ServerPlayerEntity player : players) {
+				player.sendMessage(Text.of(sleepingPlayerCount + "/" + playerCount + " players are currently sleeping. " + playersRequiredToSleep + "/" + playerCount + " players are required to sleep through the night."), true);
+			}
+
+			return;
+		}
 
 		// Advance time
 		worldProperties.setTime(worldProperties.getTime() + nightTimeStepPerTick);
@@ -117,6 +130,9 @@ public abstract class ServerWorldMixin extends World {
 
 		// Check if it's dawn
 		if (secondsUntilAwake <= 1) {
+			// Advance days counter
+
+
 			// Check if it's raining or thundering
 			if (worldProperties.isRaining() || worldProperties.isThundering()) {
 				// Clear weather and reset weather clock

--- a/src/main/java/com/github/steveplays28/realisticsleep/mixin/ServerWorldMixin.java
+++ b/src/main/java/com/github/steveplays28/realisticsleep/mixin/ServerWorldMixin.java
@@ -107,23 +107,9 @@ public abstract class ServerWorldMixin extends World {
 		if (secondsUntilAwake < maxSecondsUntilAwake) {
 			for (ServerPlayerEntity player : players) {
 				if (worldProperties.isThundering()) {
-					if (sleepingPlayerCount > 1) {
-						player.sendMessage(Text.of(sleepingPlayerCount + " players are sleeping through this thunderstorm (time until dawn: " + secondsUntilAwake + "s)"), true);
-					} else {
-						player.sendMessage(Text.of(sleepingPlayerCount + " player is sleeping through this thunderstorm (time until dawn: " + secondsUntilAwake + "s)"), true);
-					}
-				} else if (dayLightCycle) {
-					if (sleepingPlayerCount > 1) {
-						player.sendMessage(Text.of(sleepingPlayerCount + " players are sleeping through this night (time until dawn: " + secondsUntilAwake + "s)"), true);
-					} else {
-						player.sendMessage(Text.of(sleepingPlayerCount + " player is sleeping through this night (time until dawn: " + secondsUntilAwake + "s)"), true);
-					}
+					player.sendMessage(Text.of(sleepingPlayerCount + "/" + playerCount + " players are sleeping through this thunderstorm (time until dawn: " + secondsUntilAwake + "s)"), true);
 				} else {
-					if (sleepingPlayerCount > 1) {
-						player.sendMessage(Text.of(sleepingPlayerCount + " players are sleeping (time until dawn: " + secondsUntilAwake + "s)"), true);
-					} else {
-						player.sendMessage(Text.of(sleepingPlayerCount + " player is sleeping (time until dawn: " + secondsUntilAwake + "s)"), true);
-					}
+					player.sendMessage(Text.of(sleepingPlayerCount + "/" + playerCount + " players are sleeping through this night (time until dawn: " + secondsUntilAwake + "s)"), true);
 				}
 			}
 		}

--- a/src/main/java/com/github/steveplays28/realisticsleep/mixin/ServerWorldMixin.java
+++ b/src/main/java/com/github/steveplays28/realisticsleep/mixin/ServerWorldMixin.java
@@ -116,8 +116,7 @@ public abstract class ServerWorldMixin extends World {
 
 		// Check if it's dawn
 		if (secondsUntilAwake <= 1) {
-			// Advance days counter
-
+			// TODO: Advance days counter
 
 			// Check if it's raining or thundering
 			if (worldProperties.isRaining() || worldProperties.isThundering()) {

--- a/src/main/java/com/github/steveplays28/realisticsleep/mixin/ServerWorldMixin.java
+++ b/src/main/java/com/github/steveplays28/realisticsleep/mixin/ServerWorldMixin.java
@@ -4,16 +4,17 @@ import com.github.steveplays28.realisticsleep.SleepMath;
 import net.minecraft.network.packet.s2c.play.WorldTimeUpdateS2CPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerChunkManager;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.server.world.SleepManager;
 import net.minecraft.text.Text;
 import net.minecraft.util.profiler.Profiler;
 import net.minecraft.util.registry.RegistryEntry;
 import net.minecraft.util.registry.RegistryKey;
+import net.minecraft.village.raid.RaidManager;
 import net.minecraft.world.GameRules;
 import net.minecraft.world.MutableWorldProperties;
 import net.minecraft.world.World;
-import net.minecraft.world.chunk.ChunkManager;
 import net.minecraft.world.dimension.DimensionType;
 import net.minecraft.world.level.ServerWorldProperties;
 import org.spongepowered.asm.mixin.Final;
@@ -45,6 +46,12 @@ public abstract class ServerWorldMixin extends World {
 	@Shadow
 	@Final
 	private SleepManager sleepManager;
+	@Shadow
+	@Final
+	private ServerChunkManager chunkManager;
+	@Shadow
+	@Final
+	protected RaidManager raidManager;
 
 	protected ServerWorldMixin(MutableWorldProperties properties, RegistryKey<World> registryRef, RegistryEntry<DimensionType> registryEntry, Supplier<Profiler> profiler, boolean isClient, boolean debugWorld, long seed, int maxChainedNeighborUpdates) {
 		super(properties, registryRef, registryEntry, profiler, isClient, debugWorld, seed, maxChainedNeighborUpdates);
@@ -59,14 +66,15 @@ public abstract class ServerWorldMixin extends World {
 			return;
 		}
 
-		// Fetch values and do calculations
+		// Fetch config values and do calculations
 		int playerCount = server.getCurrentPlayerCount();
 		double sleepingRatio = (double) sleepingPlayerCount / playerCount;
 		double sleepingPercentage = sleepingRatio * 100;
 		int nightTimeStepPerTick = SleepMath.calculateNightTimeStepPerTick(sleepingRatio, config.sleepSpeedMultiplier);
 		int blockEntityTickSpeedMultiplier = (int) Math.round((double) config.blockEntityTickSpeedMultiplier);
 		int chunkTickSpeedMultiplier = (int) Math.round((double) config.chunkTickSpeedMultiplier);
-		boolean dayLightCycle = server.getGameRules().getBoolean(GameRules.DO_DAYLIGHT_CYCLE);
+		int raidTickSpeedMultiplier = (int) Math.round((double) config.raidTickSpeedMultiplier);
+		boolean doDayLightCycle = server.getGameRules().getBoolean(GameRules.DO_DAYLIGHT_CYCLE);
 		int playersRequiredToSleepPercentage = server.getGameRules().getInt(GameRules.PLAYERS_SLEEPING_PERCENTAGE);
 		double playersRequiredToSleepRatio = server.getGameRules().getInt(GameRules.PLAYERS_SLEEPING_PERCENTAGE) / 100;
 		int playersRequiredToSleep = (int) Math.ceil(playersRequiredToSleepRatio * playerCount);
@@ -82,8 +90,8 @@ public abstract class ServerWorldMixin extends World {
 
 		// Advance time
 		worldProperties.setTime(worldProperties.getTime() + nightTimeStepPerTick);
-		if (dayLightCycle) {
-			worldProperties.setTimeOfDay((worldProperties.getTimeOfDay() + nightTimeStepPerTick) % DAY_LENGTH);
+		if (doDayLightCycle) {
+			worldProperties.setTimeOfDay(worldProperties.getTimeOfDay() + nightTimeStepPerTick);
 		}
 
 		// Tick block entities and chunks
@@ -92,19 +100,21 @@ public abstract class ServerWorldMixin extends World {
 		}
 
 		for (int i = chunkTickSpeedMultiplier; i > 1; i--) {
-			ChunkManager chunkManager = this.getChunkManager();
 			chunkManager.tick(shouldKeepTicking, true);
 		}
 
+		for (int i = raidTickSpeedMultiplier; i > 1; i--) {
+			raidManager.tick();
+		}
+
 		// Send new time to all players in the overworld
-		server.getPlayerManager().sendToDimension(new WorldTimeUpdateS2CPacket(worldProperties.getTime(), worldProperties.getTimeOfDay(), dayLightCycle), getRegistryKey());
+		server.getPlayerManager().sendToDimension(new WorldTimeUpdateS2CPacket(worldProperties.getTime(), worldProperties.getTimeOfDay(), doDayLightCycle), getRegistryKey());
 
 		// Send HUD message to all players
 		// TODO: Don't assume the TPS is 20
-		int secondsUntilAwake = SleepMath.calculateSecondsUntilAwake((int) worldProperties.getTimeOfDay(), nightTimeStepPerTick, 20);
-		int maxSecondsUntilAwake = SleepMath.calculateSecondsUntilAwake(DAY_LENGTH, nightTimeStepPerTick, 20);
+		int secondsUntilAwake = Math.abs(SleepMath.calculateSecondsUntilAwake((int) worldProperties.getTimeOfDay() % 24000, nightTimeStepPerTick, 20));
 
-		if (secondsUntilAwake < maxSecondsUntilAwake) {
+		if (secondsUntilAwake >= 2) {
 			for (ServerPlayerEntity player : players) {
 				if (worldProperties.isThundering()) {
 					player.sendMessage(Text.of(sleepingPlayerCount + "/" + playerCount + " players are sleeping through this thunderstorm (time until dawn: " + secondsUntilAwake + "s)"), true);
@@ -115,15 +125,13 @@ public abstract class ServerWorldMixin extends World {
 		}
 
 		// Check if it's dawn
-		if (secondsUntilAwake <= 1) {
-			// TODO: Advance days counter
-
+		if (secondsUntilAwake < 2) {
 			// Check if it's raining or thundering
 			if (worldProperties.isRaining() || worldProperties.isThundering()) {
 				// Clear weather and reset weather clock
 				worldProperties.setThundering(false);
 				worldProperties.setRaining(false);
-				worldProperties.setClearWeatherTime((int) (DAY_LENGTH * SleepMath.getRandomNumber(1.25, 3)));
+				worldProperties.setClearWeatherTime((int) (DAY_LENGTH * SleepMath.getRandomNumberInRange(0.5, 7.5)));
 			}
 
 			// Check if dawn message isn't set to nothing

--- a/src/main/resources/assets/realisticsleep/lang/en_us.json
+++ b/src/main/resources/assets/realisticsleep/lang/en_us.json
@@ -7,5 +7,9 @@
   "text.autoconfig.realisticsleep.option.blockEntityTickSpeedMultiplier": "Block entity tick speed multiplier",
   "text.autoconfig.realisticsleep.option.blockEntityTickSpeedMultiplier.@Tooltip": "How many times faster block entities like furnaces should tick.",
   "text.autoconfig.realisticsleep.option.chunkTickSpeedMultiplier": "Chunk tick speed multiplier",
-  "text.autoconfig.realisticsleep.option.chunkTickSpeedMultiplier.@Tooltip": "How many times faster chunks should tick."
+  "text.autoconfig.realisticsleep.option.chunkTickSpeedMultiplier.@Tooltip": "How many times faster chunks should tick.",
+  "text.autoconfig.realisticsleep.option.raidTickSpeedMultiplier": "Raid tick speed multiplier",
+  "text.autoconfig.realisticsleep.option.raidTickSpeedMultiplier.@Tooltip": "How many times faster raid timers should tick .",
+  "text.autoconfig.realisticsleep.option.entityTickSpeedMultiplier": "Entity tick speed multiplier",
+  "text.autoconfig.realisticsleep.option.entityTickSpeedMultiplier.@Tooltip": "How many times faster entities should tick."
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -8,6 +8,7 @@
     "Steveplays28"
   ],
   "contact": {
+    "homepage": "https://modrinth.com/mod/realisticsleep",
     "sources": "https://github.com/Steveplays28/realisticsleep",
     "issues": "https://github.com/Steveplays28/realisticsleep/issues"
   },


### PR DESCRIPTION
This PR includes both fixes and new features, scheduled to release in 1.6.0.

- Fix the day counter resetting to 0 every time you sleep
  Closes #5, closes #6

- Add support for the `PLAYER_SLEEP_PERCENTAGE` gamerule
  Closes #8

- Add a speedup to the raid timer when sleeping, and a matching config option

- Bump version number 1.5.3->1.6.0