### PR TITLE
More Configurability

### DIFF
--- a/src/main/java/com/github/steveplays28/realisticsleep/config/RealisticSleepConfig.java
+++ b/src/main/java/com/github/steveplays28/realisticsleep/config/RealisticSleepConfig.java
@@ -14,6 +14,8 @@ public class RealisticSleepConfig implements ConfigData {
 	@ConfigEntry.Gui.Tooltip
 	public boolean sendSleepingMessage = true;
 	@ConfigEntry.Gui.Tooltip
+	public boolean showTimeUntilDawn = true;
+	@ConfigEntry.Gui.Tooltip
 	public boolean sendNotEnoughPlayersSleepingMessage = true;
 
 	@ConfigEntry.Gui.Tooltip

--- a/src/main/java/com/github/steveplays28/realisticsleep/config/RealisticSleepConfig.java
+++ b/src/main/java/com/github/steveplays28/realisticsleep/config/RealisticSleepConfig.java
@@ -7,7 +7,10 @@ import me.shedaniel.autoconfig.annotation.ConfigEntry;
 @Config(name = "realisticsleep")
 public class RealisticSleepConfig implements ConfigData {
 	@ConfigEntry.Gui.Tooltip
+	public boolean sendDawnMessage = true;
+	@ConfigEntry.Gui.Tooltip
 	public String dawnMessage = "The sun rises.";
+
 	@ConfigEntry.Gui.Tooltip
 	public boolean sendSleepingMessage = true;
 	@ConfigEntry.Gui.Tooltip

--- a/src/main/java/com/github/steveplays28/realisticsleep/mixin/ServerWorldMixin.java
+++ b/src/main/java/com/github/steveplays28/realisticsleep/mixin/ServerWorldMixin.java
@@ -37,6 +37,8 @@ public abstract class ServerWorldMixin extends World {
 	public double nightTimeStepPerTick = 1;
 	public int nightTimeStepPerTickRounded = 1;
 	public long tickDelay;
+	public long lastFluidTick;
+	public String sleepMessage;
 
 	@Shadow
 	@Final
@@ -146,18 +148,11 @@ public abstract class ServerWorldMixin extends World {
 		// Check if players are still supposed to be sleeping, and send a HUD message if so
 		if (secondsUntilAwake >= 2) {
 			if (config.sendSleepingMessage) {
+				sleepMessage = String.format("%d/%d players are sleeping through this %s", sleepingPlayerCount, playerCount, worldProperties.isThundering() ? "thunderstorm" : "night");
+				if (config.showTimeUntilDawn) sleepMessage += String.format(" (Time until dawn: %d", secondsUntilAwake) + "s)";
+
 				for (ServerPlayerEntity player : players) {
-					if (worldProperties.isThundering()) {
-						player.sendMessage(
-								Text.of(sleepingPlayerCount + "/" + playerCount + " players are sleeping through this thunderstorm (time until dawn: " + secondsUntilAwake + "s)"),
-								true
-						);
-					} else {
-						player.sendMessage(
-								Text.of(sleepingPlayerCount + "/" + playerCount + " players are sleeping through this night (time until dawn: " + secondsUntilAwake + "s)"),
-								true
-						);
-					}
+					player.sendMessage(Text.of(sleepMessage), true);
 				}
 			}
 		}

--- a/src/main/java/com/github/steveplays28/realisticsleep/mixin/ServerWorldMixin.java
+++ b/src/main/java/com/github/steveplays28/realisticsleep/mixin/ServerWorldMixin.java
@@ -175,10 +175,9 @@ public abstract class ServerWorldMixin extends World {
 			// Wake up sleeping players
 			wakeSleepingPlayers();
 
-			// Check if dawn message isn't set to nothing
-			if (config.dawnMessage.equals("")) {
-				return;
-			}
+			// Return if we shouldn't send the dawn message
+			if (!config.sendDawnMessage || config.dawnMessage.equals("")) return;
+
 			// Send HUD message to all players
 			for (ServerPlayerEntity player : players) {
 				player.sendMessage(Text.of(config.dawnMessage), true);

--- a/src/main/java/com/github/steveplays28/realisticsleep/mixin/ServerWorldMixin.java
+++ b/src/main/java/com/github/steveplays28/realisticsleep/mixin/ServerWorldMixin.java
@@ -1,8 +1,6 @@
 package com.github.steveplays28.realisticsleep.mixin;
 
 import com.github.steveplays28.realisticsleep.SleepMath;
-import net.minecraft.block.Block;
-import net.minecraft.fluid.Fluid;
 import net.minecraft.network.packet.s2c.play.WorldTimeUpdateS2CPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -10,7 +8,6 @@ import net.minecraft.server.world.ServerChunkManager;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.server.world.SleepManager;
 import net.minecraft.text.Text;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.profiler.Profiler;
 import net.minecraft.util.registry.RegistryEntry;
 import net.minecraft.util.registry.RegistryKey;
@@ -20,7 +17,6 @@ import net.minecraft.world.MutableWorldProperties;
 import net.minecraft.world.World;
 import net.minecraft.world.dimension.DimensionType;
 import net.minecraft.world.level.ServerWorldProperties;
-import net.minecraft.world.tick.WorldTickScheduler;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
@@ -41,7 +37,6 @@ public abstract class ServerWorldMixin extends World {
 	public double nightTimeStepPerTick = 1;
 	public int nightTimeStepPerTickRounded = 1;
 	public long tickDelay;
-	public long lastFluidTick;
 
 	@Shadow
 	@Final
@@ -64,12 +59,6 @@ public abstract class ServerWorldMixin extends World {
 	@Shadow
 	@Final
 	private boolean shouldTickTime;
-	@Shadow
-	@Final
-	private WorldTickScheduler<Fluid> fluidTickScheduler;
-	@Shadow
-	@Final
-	private WorldTickScheduler<Block> blockTickScheduler;
 
 	protected ServerWorldMixin(MutableWorldProperties properties, RegistryKey<World> registryRef, RegistryEntry<DimensionType> registryEntry, Supplier<Profiler> profiler, boolean isClient, boolean debugWorld, long seed, int maxChainedNeighborUpdates) {
 		super(properties, registryRef, registryEntry, profiler, isClient, debugWorld, seed, maxChainedNeighborUpdates);
@@ -77,12 +66,6 @@ public abstract class ServerWorldMixin extends World {
 
 	@Shadow
 	protected abstract void wakeSleepingPlayers();
-
-	@Shadow
-	protected abstract void tickFluid(BlockPos pos, Fluid fluid);
-
-	@Shadow
-	protected abstract void tickBlock(BlockPos pos, Block block);
 
 	@Inject(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/GameRules;getInt(Lnet/minecraft/world/GameRules$Key;)I"))
 	public void tickInject(BooleanSupplier shouldKeepTicking, CallbackInfo ci) {
@@ -98,7 +81,8 @@ public abstract class ServerWorldMixin extends World {
 		double sleepingRatio = (double) sleepingPlayerCount / playerCount;
 		double sleepingPercentage = sleepingRatio * 100;
 
-		nightTimeStepPerTick = SleepMath.calculateNightTimeStepPerTick(sleepingRatio, config.sleepSpeedMultiplier, nightTimeStepPerTick);
+		nightTimeStepPerTick = SleepMath.calculateNightTimeStepPerTick(
+				sleepingRatio, config.sleepSpeedMultiplier, nightTimeStepPerTick);
 		nightTimeStepPerTickRounded = (int) Math.round(nightTimeStepPerTick);
 
 		int blockEntityTickSpeedMultiplier = (int) Math.round(config.blockEntityTickSpeedMultiplier);
@@ -117,7 +101,10 @@ public abstract class ServerWorldMixin extends World {
 			}
 
 			for (ServerPlayerEntity player : players) {
-				player.sendMessage(Text.of(sleepingPlayerCount + "/" + playerCount + " players are currently sleeping. " + playersRequiredToSleep + "/" + playerCount + " players are required to sleep through the night."), true);
+				player.sendMessage(
+						Text.of(sleepingPlayerCount + "/" + playerCount + " players are currently sleeping. " + playersRequiredToSleep + "/" + playerCount + " players are required to sleep through the night."),
+						true
+				);
 			}
 
 			return;
@@ -144,20 +131,32 @@ public abstract class ServerWorldMixin extends World {
 		}
 
 		// Send new time to all players in the overworld
-		server.getPlayerManager().sendToDimension(new WorldTimeUpdateS2CPacket(worldProperties.getTime(), worldProperties.getTimeOfDay(), doDayLightCycle), getRegistryKey());
+		server.getPlayerManager().sendToDimension(
+				new WorldTimeUpdateS2CPacket(worldProperties.getTime(), worldProperties.getTimeOfDay(),
+						doDayLightCycle
+				), getRegistryKey());
 
 		// Send HUD message to all players
 		// TODO: Don't assume the TPS is 20
-		int secondsUntilAwake = Math.abs(SleepMath.calculateSecondsUntilAwake((int) worldProperties.getTimeOfDay() % 24000, nightTimeStepPerTick, 20));
+		int secondsUntilAwake = Math.abs(
+				SleepMath.calculateSecondsUntilAwake((int) worldProperties.getTimeOfDay() % 24000, nightTimeStepPerTick,
+						20
+				));
 
 		// Check if players are still supposed to be sleeping, and send a HUD message if so
 		if (secondsUntilAwake >= 2) {
 			if (config.sendSleepingMessage) {
 				for (ServerPlayerEntity player : players) {
 					if (worldProperties.isThundering()) {
-						player.sendMessage(Text.of(sleepingPlayerCount + "/" + playerCount + " players are sleeping through this thunderstorm (time until dawn: " + secondsUntilAwake + "s)"), true);
+						player.sendMessage(
+								Text.of(sleepingPlayerCount + "/" + playerCount + " players are sleeping through this thunderstorm (time until dawn: " + secondsUntilAwake + "s)"),
+								true
+						);
 					} else {
-						player.sendMessage(Text.of(sleepingPlayerCount + "/" + playerCount + " players are sleeping through this night (time until dawn: " + secondsUntilAwake + "s)"), true);
+						player.sendMessage(
+								Text.of(sleepingPlayerCount + "/" + playerCount + " players are sleeping through this night (time until dawn: " + secondsUntilAwake + "s)"),
+								true
+						);
 					}
 				}
 			}
@@ -210,16 +209,10 @@ public abstract class ServerWorldMixin extends World {
 
 		if (tickDelay > 0L) {
 			tickDelay -= 1L;
-			server.getPlayerManager().sendToDimension(new WorldTimeUpdateS2CPacket(worldProperties.getTime(), worldProperties.getTimeOfDay(), this.properties.getGameRules().getBoolean(GameRules.DO_DAYLIGHT_CYCLE)), getRegistryKey());
-
-//			if (lastFluidTick >= 4) {
-//				this.fluidTickScheduler.tick(this.properties.getTime() + config.tickDelay - tickDelay, 65536, this::tickFluid);
-//				this.lastFluidTick = 0;
-//			} else {
-//				this.lastFluidTick += 1;
-//			}
-//
-//			this.blockTickScheduler.tick(this.properties.getTime() + config.tickDelay - tickDelay, 65536, this::tickBlock);
+			server.getPlayerManager().sendToDimension(
+					new WorldTimeUpdateS2CPacket(worldProperties.getTime(), worldProperties.getTimeOfDay(),
+							this.properties.getGameRules().getBoolean(GameRules.DO_DAYLIGHT_CYCLE)
+					), getRegistryKey());
 
 			ci.cancel();
 			return;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -41,8 +41,7 @@
   "depends": {
     "fabricloader": ">=0.14.8",
     "minecraft": [
-      "1.18.x",
-      "1.19.x"
+      "<1.20 >=1.18"
     ],
     "cloth-config": ">=5.3.63",
     "fabric": ">=0.48.0"


### PR DESCRIPTION
Adds two config options:

sendDawnMessage - specifies whether to send the dawn message, makes sense since a "sendSleepingMessage" option is also provided and makes disabling the message more obvious

showTimeUntilDawn - specifies whether the time until dawn should be appended to the sleeping message, made true by default. Allows for greater vanilla parity 

Also changed the construction of the sleeping message to use String.format() which would maybe have a tiiiiiiny improvement for memory use lol