### PR TITLE
Fix playersSleepingPercentage=0 affecting crop growth

### DIFF
--- a/common/src/main/java/io/github/steveplays28/stevesrealisticsleep/api/StevesRealisticSleepApi.java
+++ b/common/src/main/java/io/github/steveplays28/stevesrealisticsleep/api/StevesRealisticSleepApi.java
@@ -57,6 +57,8 @@ public class StevesRealisticSleepApi {
 		var sleepingPlayers = players.stream().filter(LivingEntity::isSleeping);
 		var playerCount = players.size();
 		var sleepingPlayerCount = sleepingPlayers.count();
+        if(sleepingPlayerCount == 0) return false;
+
 		double sleepingRatio = (double) sleepingPlayerCount / playerCount;
 		double sleepingPercentage = sleepingRatio * 100;
 		int playersRequiredToSleepPercentage = world.getGameRules().getInt(GameRules.PLAYERS_SLEEPING_PERCENTAGE);
@@ -71,6 +73,8 @@ public class StevesRealisticSleepApi {
 	public static boolean isSleeping(@NotNull ServerWorld world) {
 		var playerCount = world.getPlayers().size();
 		var sleepingPlayerCount = ((ServerWorldAccessor) world).getSleepManager().getSleeping();
+        if(sleepingPlayerCount == 0) return false;
+
 		double sleepingRatio = (double) sleepingPlayerCount / playerCount;
 		double sleepingPercentage = sleepingRatio * 100d;
 		int playersRequiredToSleepPercentage = world.getGameRules().getInt(GameRules.PLAYERS_SLEEPING_PERCENTAGE);


### PR DESCRIPTION
(... and other random ticks)
This is just a simple change in the `isSleeping` part of the API, making it return false if no players are sleeping. Before, if no players were sleeping and the playersSleepingPercentage was 0, well, 0% players sleeping satisfies that, and the mod thought players were sleeping.

Closes #85.
Closes #79.